### PR TITLE
Scheduler fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,7 +10,7 @@
 static struct player player = {0};
 
 static const char * usage_str =
-  "Usage: %s [-s audio_sink_bin] [-d debug_level] [-m debug_mask] <config_file>\n";
+  "Usage: %s [-s audio_sink_bin] [-d debug_level] [-m debug_mask] [-p port] <config_file>\n";
 
 static void
 signal_handler(int sig, siginfo_t * info, void *extra)
@@ -27,9 +27,10 @@ main(int argc, char **argv)
 	int ret = 0, opt, tmp;
 	int dbg_lvl = DBG;
 	int dbg_mask = PLR|SCHED|META;
+	uint16_t port = 9670;
 	char *sink = NULL;
 
-	while ((opt = getopt(argc, argv, "s:d:m:")) != -1) {
+	while ((opt = getopt(argc, argv, "s:d:m:p:")) != -1) {
 		switch (opt) {
 		case 's':
 			sink = optarg;
@@ -47,6 +48,13 @@ main(int argc, char **argv)
 				perror("Failed to parse debug mask");
 			else
 				dbg_mask = tmp;
+			break;
+		case 'p':
+			tmp = strtol(optarg, NULL, 10);
+			if (errno != 0)
+				perror("Failed to parse port number");
+			else
+				port = tmp;
 			break;
 		default:
 			printf(usage_str, argv[0]);
@@ -69,7 +77,7 @@ main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	ret = meta_handler_init(&mh, 9670, NULL);
+	ret = meta_handler_init(&mh, port, NULL);
 	if (ret < 0) {
 		utils_err(NONE, "Unable to initialize metadata request hanlder\n");
 		ret = -2;

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ main(int argc, char **argv)
 	struct sigaction sa = {0};
 	struct meta_handler mh = {0};
 	int ret = 0, opt, tmp;
-	int dbg_lvl = DBG;
+	int dbg_lvl = INFO;
 	int dbg_mask = PLR|SCHED|META;
 	uint16_t port = 9670;
 	char *sink = NULL;

--- a/scheduler.c
+++ b/scheduler.c
@@ -141,6 +141,12 @@ sched_get_next(struct scheduler* sched, time_t sched_time, char** next,
 	for(i = ds->num_zones - 1; i >= 0; i--) {
 		zn = ds->zones[i];
 		ret = utils_compare_time(&tm, &zn->start_time, 1);
+
+		if (utils_is_debug_enabled (SCHED)) {
+			strftime (datestr, 26, "%H:%M:%S", &zn->start_time);
+			utils_dbg (SCHED, "considering zone '%s' at: %s -> %i\n",
+					zn->name, datestr, ret);
+		}
 		if(ret > 0)
 			break;
 	}
@@ -215,8 +221,8 @@ sched_get_next(struct scheduler* sched, time_t sched_time, char** next,
 
 done:
 	if((*next) != NULL) {
-		utils_info(SCHED, "Got next item: %s (fader: %s)\n",
-			  (*next), (*fader) ? "true" : "false");
+		utils_info(SCHED, "Got next item from zone '%s': %s (fader: %s)\n",
+			zn->name, (*next), (*fader) ? "true" : "false");
 		return 0;
 	}
 

--- a/utils.c
+++ b/utils.c
@@ -444,7 +444,7 @@ static void
 utils_tm_cleanup_date(struct tm *tm)
 {
 	/* Zero-out the date part */
-	tm->tm_mday = 0;
+	tm->tm_mday = 1;
 	tm->tm_mon = 0;
 	tm->tm_year = 70;
 	tm->tm_wday = 0;

--- a/utils.c
+++ b/utils.c
@@ -463,10 +463,13 @@ utils_compare_time(struct tm *tm1, struct tm* tm0, int no_date)
 		utils_tm_cleanup_date(tm1);
 	}
 
+	errno = 0;
 	t1 = mktime(tm1);
 	t0 = mktime(tm0);
 	diff = difftime(t1, t0);
 
+	if (errno != 0)
+		utils_perr(UTILS, "compare_time");
 	utils_dbg(UTILS, "compare_time: (t1: %li) - (t0: %li) = %lf\n", t1, t0, diff);
 
 	if(diff > 0.0L)

--- a/utils.c
+++ b/utils.c
@@ -466,6 +466,9 @@ utils_compare_time(struct tm *tm1, struct tm* tm0, int no_date)
 	t1 = mktime(tm1);
 	t0 = mktime(tm0);
 	diff = difftime(t1, t0);
+
+	utils_dbg(UTILS, "compare_time: (t1: %li) - (t0: %li) = %lf\n", t1, t0, diff);
+
 	if(diff > 0.0L)
 		return 1;
 	else if(diff < 0.0L)

--- a/utils.c
+++ b/utils.c
@@ -446,9 +446,10 @@ utils_tm_cleanup_date(struct tm *tm)
 	/* Zero-out the date part */
 	tm->tm_mday = 0;
 	tm->tm_mon = 0;
-	tm->tm_year = 0;
+	tm->tm_year = 70;
 	tm->tm_wday = 0;
 	tm->tm_yday = 0;
+	tm->tm_isdst = 0;
 }
 
 int

--- a/utils.c
+++ b/utils.c
@@ -449,7 +449,7 @@ utils_tm_cleanup_date(struct tm *tm)
 	tm->tm_year = 70;
 	tm->tm_wday = 0;
 	tm->tm_yday = 0;
-	tm->tm_isdst = 0;
+	tm->tm_isdst = -1;
 }
 
 int


### PR DESCRIPTION
I looks like this code used to work out of luck, as mktime was not reporting overflow errors.

This is the log without the fix
```
[SCHED] Scheduling item for: Sat 25 Apr 2020, 12:01:22
[UTILS] compare_time: Value too large for defined data type
[UTILS] compare_time: (t1: -1) - (t0: -2208998092) = 2208998091.000000
[SCHED] considering zone 'Ballads' at: 23:00:00 -> 1
```
The current time was causing mktime to return error, while the zone's start time would return a large negative number.
